### PR TITLE
Fix #2 Add test runner for scraper sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 
-language: ruby
+language: node_js
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+language: node_js
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - docker-compose up --build test
+  - docker-compose run --rm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 
-language: node_js
+language: ruby
 
 services:
   - docker

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -23,6 +23,16 @@ services:
       - ./scraper:/usr/src/app
       - /usr/src/app/node_modules
 
+  test:
+    image: scraper
+    depends_on:
+    - runner
+    - scraper
+    command: 'npm run test'
+    volumes:
+      - ./scraper:/usr/src/app
+      - /usr/src/app/node_modules
+
   frontend:
     restart: always
     ports:

--- a/scraper/package.json
+++ b/scraper/package.json
@@ -10,7 +10,7 @@
     "notification"
   ],
   "scripts": {
-    "test": "test",
+    "test": "tsc && node ./build/test/run-test.js",
     "build": "tsc",
     "start": "tsc && node ./build/run.js",
     "serve": "tsc && node ./build/api/server.js"

--- a/scraper/src/run.ts
+++ b/scraper/src/run.ts
@@ -31,12 +31,12 @@ const scrape = async () => {
     )
 
     const flatResults = results.reduce((acc, val) => acc.concat(val), [])
-    
+
     if (flatResults.length === 0) return;
 
     const storage = new Storage();
     await Promise.all(flatResults.map((result: Result) => storage.updateOrCreate(result)))
-    
+
     if (process.env.NOTIFY) {
         const updatedRecords = await storage.findUpdatedSince(startTime);
         await notify(updatedRecords)

--- a/scraper/src/test/run-test.ts
+++ b/scraper/src/test/run-test.ts
@@ -12,10 +12,16 @@ const scrape = async (sourcePath: string) => {
     if (source.type === 'json') return;
 
     try {
-        const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] })
+        const browser = await puppeteer.launch({
+            headless: true,
+            args: ['--no-sandbox', '--disable-setuid-sandbox'],
+            pipe: true,
+            timeout: 60000
+        })
+
         const page = await browser.newPage()
         await page.goto(source.url)
-        await page.waitForSelector(source.resultSelector)
+        await page.waitForSelector(source.resultSelector, { timeout: 60000 })
         const response = await page.content()
         await browser.close()
 

--- a/scraper/src/test/run-test.ts
+++ b/scraper/src/test/run-test.ts
@@ -1,0 +1,49 @@
+import { resolve } from 'path'
+import * as glob from 'glob'
+import * as puppeteer from 'puppeteer'
+import * as cheerio from 'cheerio'
+import * as assert from 'assert'
+
+const scrape = async (sourcePath: string) => {
+    const sourceModule: any = require(resolve(__dirname, '../', sourcePath))
+    const source = sourceModule.default()
+
+    console.log(source.type)
+
+    if (source.type === 'json') return;
+
+    const browser = await puppeteer.launch({
+        headless: true,
+        args: ['--no-sandbox', '--disable-setuid-sandbox']
+    })
+
+    const page = await browser.newPage()
+    await page.goto(source.url)
+    const response = await page.content()
+    await browser.close()
+
+    const $: CheerioStatic = cheerio.load(response)
+    const results = $(source.resultSelector)
+    const attributes = source.resultAttributes
+
+    assert(results.length > 0, `${source.resultSelector} is empty`)
+
+    results.toArray().forEach((resultElement: CheerioElement) => {
+        attributes.forEach((attribute: any) => {
+            const { type, selector } = attribute
+            assert.equal(
+                $(selector, resultElement).length, 1,
+                `${type} element with selector ${selector} is missing`
+            )
+        })
+    })
+}
+
+const sources: String[] = glob.sync(resolve(__dirname, '../source/**/*.js'))
+console.log(sources)
+
+sources.map(async (sourcePath: string) => scrape(sourcePath))
+
+// scrape('./source/leboncoin.js')
+
+export default scrape

--- a/scraper/src/test/run-test.ts
+++ b/scraper/src/test/run-test.ts
@@ -1,47 +1,69 @@
-import { resolve } from 'path'
+import { resolve, basename } from 'path'
 import * as glob from 'glob'
 import * as puppeteer from 'puppeteer'
 import * as cheerio from 'cheerio'
 import * as assert from 'assert'
 
 const scrape = async (sourcePath: string) => {
+    const sourceName = basename(sourcePath, '.js')
     const sourceModule: any = require(resolve(__dirname, '../', sourcePath))
     const source = sourceModule.default()
 
     if (source.type === 'json') return;
 
-    const browser = await puppeteer.launch({
-        headless: true,
-        args: ['--no-sandbox', '--disable-setuid-sandbox']
-    })
+    try {
+        const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] })
+        const page = await browser.newPage()
+        await page.goto(source.url)
+        await page.waitForSelector(source.resultSelector)
+        const response = await page.content()
+        await browser.close()
 
-    const page = await browser.newPage()
-    await page.goto(source.url)
-    await page.waitForSelector(source.resultSelector)
-    const response = await page.content()
-    await browser.close()
+        const $: CheerioStatic = cheerio.load(response)
+        const results = $(source.resultSelector)
+        const attributes = source.resultAttributes
 
-    const $: CheerioStatic = cheerio.load(response)
-    const results = $(source.resultSelector)
-    const attributes = source.resultAttributes
+        assert(results.length > 0, `${sourceName} - ${source.resultSelector} is empty`)
 
-    assert(results.length > 0, `${sourcePath} - ${source.resultSelector} is empty`)
+        const selectors: any = {}
 
-    results.toArray().forEach((resultElement: CheerioElement) => {
-        attributes.forEach((attribute: any) => {
-            const { type, selector } = attribute
+        results.toArray().forEach((resultElement: CheerioElement) => {
 
-            if (selector && type !== 'photo') {
-                assert(
-                    $(selector, resultElement).length > 0,
-                    `${sourcePath} - ${type} element with selector ${selector} is missing`
-                )
-            }
+            attributes.forEach((attribute: any) => {
+                const type = attribute.type
+                let selector = attribute.selector || source.resultSelector
+
+                if (!selectors[selector]) selectors[selector] = []
+
+                selectors[selector].push({
+                    selector,
+                    type,
+                    isEmpty: $(selector, resultElement).length === 0 && $(selector).length === 0
+                })
+            })
         })
-    })
+
+        for (let i in selectors) {
+            const selector = selectors[i]
+            assert.notEqual(selector.every((val: any) => val.isEmpty === true), `✖ ${sourceName} - ${i}`);
+
+            console.log(`✔ ${sourceName} - ${i}`);
+        }
+
+        console.log('\n')
+    } catch (e) {
+        console.log('Can\'t load', sourcePath, e)
+        process.exit(1)
+    }
+
 }
 
 const sources: String[] = glob.sync(resolve(__dirname, '../source/**/*.js'))
-sources.map(async (sourcePath: string) => scrape(sourcePath))
 
-export default scrape
+console.log('➡️ testing', sources, '\n')
+
+async function test() {
+    await Promise.all(sources.map(async (sourcePath: string) => scrape(sourcePath)))
+}
+
+test()

--- a/scraper/src/test/run-test.ts
+++ b/scraper/src/test/run-test.ts
@@ -45,9 +45,14 @@ const scrape = async (sourcePath: string) => {
 
         for (let i in selectors) {
             const selector = selectors[i]
-            assert.notEqual(selector.every((val: any) => val.isEmpty === true), `✖ ${sourceName} - ${i}`);
 
-            console.log(`✔ ${sourceName} - ${i}`);
+            if (selector.every((val: any) => val.isEmpty === true)) {
+                console.log(`✖ ${sourceName} - ${i}`);
+                process.exit(1)
+            } else {
+                console.log(`✔ ${sourceName} - ${i}`);
+            }
+
         }
 
         console.log('\n')

--- a/scraper/src/types/source.ts
+++ b/scraper/src/types/source.ts
@@ -10,6 +10,8 @@ class Source {
 }
 
 export class JSONSource extends Source {
+    public type = 'json'
+
     public async scrape(formatters: any[]): Promise<Result[]> {
         console.log('➡️ scraping', this.url)
         const response = await request.get(this.url, { resolveWithFullResponse: true })
@@ -37,6 +39,8 @@ export class JSONSource extends Source {
 }
 
 export class HTMLSource extends Source {
+    public type = 'html'
+
     public async scrape(formatters: any[]): Promise<Result[]> {
         const browser = await puppeteer.launch({
             headless: true,
@@ -69,7 +73,7 @@ export class HTMLSource extends Source {
 
             resultList.push(Object.assign(new Result(), resultAttributes))
         })
-        
+
         console.log('✔️ found', resultList.length, 'results for', this.url)
         return resultList
     }


### PR DESCRIPTION
This PR adds a test runner that asserts that all resultSelector and resultAttribute elements are present in each source response (for html and json) #2 

- [x] Test every selector
- [x] Set up Travis nightly tests