### PR TITLE
Fix automatic navigation between pages

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/scraper/src/driver/puppeteer.ts
+++ b/scraper/src/driver/puppeteer.ts
@@ -20,7 +20,7 @@ export default class Puppeteer {
 
      public async scrapePage(goNext: boolean, nextSelector: string, waitForSelector: string) {
         await this.scrollDown()
-        const nextLink = this.getElement(nextSelector)
+        const nextLink = await this.getElement(nextSelector)
 
         if (goNext && nextLink) {
             await this.click(nextSelector)

--- a/scraper/src/test/source/html.ts
+++ b/scraper/src/test/source/html.ts
@@ -27,6 +27,7 @@ source.resultAttributes = [
 source.driver = {
     setup: sinon.stub(),
     scrapePage: sinon.stub().returns(response),
+    getElement: sinon.stub().returns(null),
     url: sinon.stub().returns(source.url),
     shutdown: sinon.stub()
 }

--- a/scraper/src/types/html-source.ts
+++ b/scraper/src/types/html-source.ts
@@ -49,7 +49,9 @@ export class HTMLSource extends Source {
             const url = await this.driver.url()
             console.log(chalk.magenta(`   ↘ go to page ${url}`))
             results.push(this.extractResults(response, formatters))
-            if (this.nextPageSelector === null) break
+            const nextLink = await this.driver.getElement(this.nextPageSelector)
+            // Only continue on next page if we have a selector and next link is present on current page
+            if (this.nextPageSelector === null || nextLink === null) break
         }
 
         results = results.reduce((acc, val) => acc.concat(val), [])


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Details

URLs below didn't work properly before. I fixed the end condition for automatic navigation between pages, and handled the case when no navigation selector was present (only 1 page of results for instance).

[https://www.leboncoin.fr/recherche/?text=T2&category=10&region=18&cities=Nantes_44000&furnished=2&real_estate_type=2&price=min-600&rooms=2-max&square=40-max](https://www.leboncoin.fr/recherche/?text=T2&category=10&region=18&cities=Nantes_44000&furnished=2&real_estate_type=2&price=min-600&rooms=2-max&square=40-max)

[https://www.leboncoin.fr/recherche/?text=T2&category=10&region=18&cities=Nantes_44000&furnished=2&real_estate_type=2&rooms=2-max&square=40-max&page=2](https://www.leboncoin.fr/recherche/?text=T2&category=10&region=18&cities=Nantes_44000&furnished=2&real_estate_type=2&rooms=2-max&square=40-max)

BTW, a more robust navigation algorithm between pages should be implemented.